### PR TITLE
Issue 702 regression tests GitHub actions cache

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -60,10 +60,10 @@ jobs:
 
             - name: Restore previous stats file
               id: cache-stats-file
-              working-directory: ${{ github.workspace }}/tests/regression_tests
+            #   working-directory:
               uses: actions/cache@v4
               with:
-                  path: gem5/regression-tests
+                  path: ${{ github.workspace }}/tests/regression_tests
                   key: stats-${{ needs.get-date.outputs.date }}
                   restore-keys: stats-**
 

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -46,7 +46,9 @@ jobs:
         runs-on: ubuntu-latest # [self-hosted, linux, x64]
         container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
         timeout-minutes: 60
-        needs: get-date
+        needs:
+            - get-date
+            - build-all-gem5
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -67,7 +67,7 @@ jobs:
             #   working-directory:
               uses: actions/cache@v4
               with:
-                  path: ${{ github.workspace }}/tests/regression_tests
+                  path: tests/gem5/regression_tests/cached_stats.txt
                   key: stats
                   restore-keys: stats
 

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -35,7 +35,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: build/ALL
-                  key: testlib-build-all-${{ needs.get-date.outputs.date }}
+                  key: testlib-build-all #-${{ needs.get-date.outputs.date }}
                   restore-keys: |
                       testlib-build-all
 

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -67,7 +67,7 @@ jobs:
               with:
                   path: ${{ github.workspace }}/tests/regression_tests
                   key: stats-${{ needs.get-date.outputs.date }}
-                  restore-keys: stats-**
+                  restore-keys: stats
 
             - name: Run regression tests
               id: run-tests

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -1,0 +1,270 @@
+---
+# Workflow for the regression tests. This should be integrated into the daily
+# tests once testing is complete.
+
+name: Daily Regression Tests
+
+on:
+    # This is triggered weekly via the 'scheduler.yaml' workflow.
+    workflow_dispatch:
+
+jobs:
+
+    get-date:
+        runs-on: ubuntu-24.04
+        outputs:
+            date: ${{ steps.date.outputs.date }}
+        steps:
+            - name: Get the current date
+              id: date
+              run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    build-all-gem5:
+        runs-on: ubuntu-latest #[self-hosted, linux, x64]
+        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        timeout-minutes: 180
+        needs: get-date
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Cache build/ALL
+              uses: actions/cache@v4
+              with:
+                  path: build/ALL
+                  key: testlib-build-all-${{ needs.get-date.outputs.date }}
+                  restore-keys: |
+                      testlib-build-all
+
+            - name: Build ALL/gem5.opt
+              run: scons --no-compress-debug build/ALL/gem5.opt -j $(nproc)
+
+    regression-tests:
+        runs-on: ubuntu-latest # [self-hosted, linux, x64]
+        container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+        timeout-minutes: 60
+        needs: get-date
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Restore build/ALL cache
+              uses: actions/cache/restore@v4
+              with:
+                  path: build/ALL
+                  key: testlib-build-all-${{ needs.get-date.outputs.date }}
+                  restore-keys: |
+                      testlib-build-all
+
+            - name: Restore previous stats file
+              id: cache-stats-file
+              working_directory: ${{ github.workspace }}/tests/regression_tests
+              uses: actions/cache@v4
+              with:
+                  path: gem5/regression-tests
+                  key: stats-${{ needs.get-date.outputs.date }}
+                  restore-keys: stats-**
+
+            - name: Run regression tests
+              id: run-tests
+              working-directory: ${{ github.workspace }}/tests
+              run: ./main.py run gem5/regression_tests --length=long --skip-build -vv
+
+            # Skip the "Sanitize test dir for artifact name" step that's in testlib-long-tests and hard code "regression-tests" instead
+            - name: Upload results
+              if: success() || failure()
+              uses: actions/upload-artifact@v4
+              env:
+                  MY_STEP_VAR: regression-tests_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
+              with:
+                  name: regression_tests-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-long-regression-tests-status-${{ steps.run-tests.outcome
+                      }}-output
+                  path: tests/testing-results
+
+
+
+  # # this builds both unittests.fast and unittests.debug
+  #   unittests-fast-debug:
+  #       strategy:
+  #           matrix:
+  #               type: [fast, debug]
+  #       runs-on: [self-hosted, linux, x64]
+  #       container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+  #       timeout-minutes: 60
+  #       steps:
+  #           - uses: actions/checkout@v4
+
+  #           - name: Run ALL/unittests.${{ matrix.type }} UnitTests
+  #             run: scons build/ALL/unittests.${{ matrix.type }} -j $(nproc)
+
+  #   get-testlib-long-dirs:
+  #       runs-on: ubuntu-24.04
+  #       container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+  #       outputs:
+  #           test-dirs-matrix: ${{ steps.dir-matrix.outputs.test-dirs-matrix }}
+  #       steps:
+  #           - uses: actions/checkout@v4
+  #           - name: Get directories for testlib-long
+  #             working-directory: ${{ github.workspace }}/tests
+  #             id: dir-matrix
+  #             run: |
+  #                 unset PREV
+  #                 echo "test-dirs-matrix=$(\
+  #                   ./main.py list gem5 \
+  #                   --suites \
+  #                   --length=long \
+  #                   --exclude-tags gcn_gpu | \
+  #                   grep "$SUITEUID:" | \
+  #                   cut -d: -f2 | \
+  #                   cut -d/ -f 2- | \
+  #                   xargs dirname | \
+  #                   sort -u  | \
+  #                   while read x; do \
+  #                     if [ -z "${PREV}" ] || [ "$x" != "${PREV}/*" ]; then \
+  #                       PREV=$x; \
+  #                       echo $x; \
+  #                     fi; \
+  #                   done  | \
+  #                   jq -ncR '[inputs]'\
+  #                 )" >>$GITHUB_OUTPUT
+
+  # # start running all of the long tests
+  #   testlib-long-tests:
+  #       name: long-tests
+  #       runs-on: [self-hosted, linux, x64]
+  #       container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+  #       timeout-minutes: 1440 # 24 hours for entire matrix to run
+  #       needs:
+  #           - build-all-gem5
+  #           - get-testlib-long-dirs
+  #           - get-date
+  #       strategy:
+  #           fail-fast: false
+  #           matrix:
+  #               test-type: ${{ fromJson(needs.get-testlib-long-dirs.outputs.test-dirs-matrix) }}
+
+  #       steps:
+  #           - uses: actions/checkout@v4
+  #           - name: Restore build/ALL cache
+  #             uses: actions/cache/restore@v4
+  #             with:
+  #                 path: build/ALL
+  #                 key: testlib-build-all-${{ needs.get-date.outputs.date }}
+  #                 restore-keys: |
+  #                     testlib-build-all
+
+  #           - name: Run long ${{ matrix.test-type }} tests
+  #             id: run-tests
+  #             working-directory: ${{ github.workspace }}/tests
+  #             run: ./main.py run ${{ matrix.test-type }} -j$(nproc) --length=long -vv -t $(nproc) --exclude-tags gcn_gpu
+
+  #           - name: Sanitize test-dir for artifact name
+  #             id: sanitize-test-dir
+  #             if: success() || failure()
+  #             run: echo "sanitized-test-dir=$(echo '${{ matrix.test-type }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
+
+  #           - name: Upload results
+  #             if: success() || failure()
+  #             uses: actions/upload-artifact@v4
+  #             env:
+  #                 MY_STEP_VAR: ${{ steps.sanitize-test-dir.outputs.sanitized-test-dir }}_COMMIT.${{github.sha}}_RUN.${{github.run_id}}_ATTEMPT.${{github.run_attempt}}
+  #             with:
+  #                 name: daily-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-testlib-long-${{ steps.sanitize-test-dir.outputs.sanitized-test-dir
+  #                     }}-status-${{ steps.run-tests.outcome }}-output
+  #                 path: tests/testing-results
+
+
+  #   gpu-tests:
+  #       runs-on: [self-hosted, linux, x64]
+  #       container: ghcr.io/gem5/gcn-gpu:latest
+  #       timeout-minutes: 1440 # 24 hours
+  #       needs:
+  #           - get-date
+
+  #       steps:
+  #           - uses: actions/checkout@v4
+  #           - name: Cache build/VEGA_X86
+  #             uses: actions/cache@v4
+  #             with:
+  #                 path: build/VEGA_X86
+  #                 key: testlib-build-vega-${{ needs.get-date.outputs.date }}
+  #                 restore-keys: |
+  #                     testlib-build-vega
+
+
+  #           - name: Run Testlib GPU Tests
+  #             id: run-tests
+  #             working-directory: ${{ github.workspace }}/tests
+  #             run: ./main.py run --length=long -vvv -j $(nproc) --host gcn_gpu
+
+  #           - name: Upload results
+  #             if: success() || failure()
+  #             uses: actions/upload-artifact@v4
+  #             with:
+  #                 name: ci-tests-run-${{ github.run_number }}-attempt-${{ github.run_attempt }}-gpu-status-${{ steps.run-tests.outcome }}-output
+  #                 path: tests/testing-results
+
+  # # This runs the SST-gem5 integration compilation and tests it with
+  # # ext/sst/sst/example.py.
+  #   sst-test:
+  #       runs-on: [self-hosted, linux, x64]
+  #       container: ghcr.io/gem5/sst-env:latest
+  #       timeout-minutes: 180
+
+  #       steps:
+  #           - uses: actions/checkout@v4
+  #           - name: Build RISCV/libgem5_opt.so with SST
+  #             run: scons build/RISCV/libgem5_opt.so --without-tcmalloc --duplicate-sources --ignore-style -j $(nproc)
+  #           - name: Makefile ext/sst
+  #             working-directory: ${{ github.workspace }}/ext/sst
+  #             run: mv Makefile.linux Makefile
+  #           - name: Compile ext/sst
+  #             working-directory: ${{ github.workspace }}/ext/sst
+  #             run: make -j $(nproc)
+  #           - name: Run SST test
+  #             working-directory: ${{ github.workspace }}/ext/sst
+  #             run: sst --add-lib-path=./ sst/example.py
+
+  # # This runs the gem5 within SystemC ingration and runs a simple hello-world
+  # # simulation with it.
+  #   systemc-test:
+  #       runs-on: [self-hosted, linux, x64]
+  #       container: ghcr.io/gem5/systemc-env:latest
+  #       timeout-minutes: 180
+
+  #       steps:
+  #           - uses: actions/checkout@v4
+  #           - name: Build ARM/gem5.opt
+  #             run: scons build/ARM/gem5.opt --ignore-style --duplicate-sources -j$(nproc)
+  #           - name: disable systemc
+  #             run: scons setconfig build/ARM --ignore-style USE_SYSTEMC=n
+  #           - name: Build ARM/libgem5_opt.so
+  #             run: scons build/ARM/libgem5_opt.so --with-cxx-config --without-python --without-tcmalloc -j$(nproc) --duplicate-sources
+  #           - name: Compile gem5 withing SystemC
+  #             working-directory: ${{ github.workspace }}/util/systemc/gem5_within_systemc
+  #             run: make
+  #           - name: Run gem5 within SystemC test
+  #             run: ./build/ARM/gem5.opt configs/deprecated/example/se.py -c tests/test-progs/hello/bin/arm/linux/hello
+  #           - name: Continue gem5 within SystemC test
+  #             run: LD_LIBRARY_PATH=build/ARM/:/opt/systemc/lib-linux64/ ./util/systemc/gem5_within_systemc/gem5.opt.sc m5out/config.ini
+
+  #   dramsys-tests:
+  #       runs-on: [self-hosted, linux, x64]
+  #       container: ghcr.io/gem5/ubuntu-24.04_all-dependencies:latest
+  #       timeout-minutes: 360 # 6 hours
+  #       steps:
+  #           - uses: actions/checkout@v4
+  #           - name: Checkout DRAMSys
+  #             working-directory: ${{ github.workspace }}/ext/dramsys
+  #             run: git clone https://github.com/tukl-msd/DRAMSys --branch v5.1 --depth 1 DRAMSys
+
+  #             # gem5 is built separately because it depends on the DRAMSys library
+  #           - name: Build gem5
+  #             working-directory: ${{ github.workspace }}
+  #             run: scons build/ALL/gem5.opt -j $(nproc)
+
+  #           - name: Run DRAMSys Checks
+  #             working-directory: ${{ github.workspace }}
+  #             run: |
+  #                 ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/arm-hello-dramsys.py
+  #                 ./build/ALL/gem5.opt configs/example/gem5_library/dramsys/dramsys-traffic.py
+  #                 ./build/ALL/gem5.opt configs/example/dramsys.py

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -66,7 +66,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ github.workspace }}/tests/regression_tests
-                  key: stats-${{ needs.get-date.outputs.date }}
+                  key: stats
                   restore-keys: stats
 
             - name: Run regression tests

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -60,7 +60,7 @@ jobs:
 
             - name: Restore previous stats file
               id: cache-stats-file
-              working_directory: ${{ github.workspace }}/tests/regression_tests
+              working-directory: ${{ github.workspace }}/tests/regression_tests
               uses: actions/cache@v4
               with:
                   path: gem5/regression-tests

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -32,6 +32,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Cache build/ALL
+              id: cache-all
               uses: actions/cache@v4
               with:
                   path: build/ALL
@@ -40,6 +41,7 @@ jobs:
                       testlib-build-all
 
             - name: Build ALL/gem5.opt
+              if: steps.cache-all.outputs.cache-hit != 'true'
               run: scons --no-compress-debug build/ALL/gem5.opt -j $(nproc)
 
     regression-tests:

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -5,6 +5,9 @@
 name: Daily Regression Tests
 
 on:
+    push:
+        branches:
+            - issue-702-regression-tests
     # This is triggered weekly via the 'scheduler.yaml' workflow.
     workflow_dispatch:
 

--- a/tests/gem5/regression_tests/configs/kernel-boot.py
+++ b/tests/gem5/regression_tests/configs/kernel-boot.py
@@ -84,8 +84,8 @@ memory = SingleChannelDDR3_1600(size="3GiB")
 #     num_cores=1,
 # )
 processor = SimpleProcessor(
-    # cpu_type=CPUTypes.KVM,  # switch to ATOMIC for final
-    cpu_type=CPUTypes.ATOMIC,
+    cpu_type=CPUTypes.KVM,  # switch to ATOMIC for final
+    # cpu_type=CPUTypes.ATOMIC,
     isa=ISA.X86,
     num_cores=1,
 )
@@ -128,7 +128,10 @@ try:
     if (new_ipc / old_ipc) < 0.8:
         print(f"New IPC is less than 80% of the old IPC!")
         exit(1)
-
+except FileNotFoundError:
+    print("One of the stats files was not found!")
+except KeyError:
+    print("One of the stats files might be empty!")
 finally:
     shutil.move(
         f"{m5.options.outdir}/stats.txt",

--- a/tests/gem5/regression_tests/configs/kernel-boot.py
+++ b/tests/gem5/regression_tests/configs/kernel-boot.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import shutil
+
+import m5
+
+from gem5.components.boards.x86_board import X86Board
+from gem5.components.cachehierarchies.classic.private_l1_private_l2_cache_hierarchy import (
+    PrivateL1PrivateL2CacheHierarchy,
+)
+from gem5.components.memory import SingleChannelDDR3_1600
+from gem5.components.processors.cpu_types import CPUTypes
+from gem5.components.processors.simple_processor import SimpleProcessor
+from gem5.components.processors.simple_switchable_processor import (
+    SimpleSwitchableProcessor,
+)
+from gem5.isas import ISA
+from gem5.resources.resource import obtain_resource
+from gem5.simulate.exit_handler import KernelBootedExitHandler
+from gem5.simulate.simulator import Simulator
+from gem5.utils.override import overrides
+
+
+class KernelBootProcessorSwitch(KernelBootedExitHandler):
+    @overrides(KernelBootedExitHandler)
+    def _process(self, simulator: "Simulator") -> None:
+        m5.stats.dump()
+        m5.stats.reset()
+        print("Dumping and resetting stats at kernel boot! Hypercall 1")
+
+    @overrides(KernelBootedExitHandler)
+    def _exit_simulation(self) -> bool:
+        return True
+
+
+def read_stats_files(filepath: str, stats_dict: dict) -> None:
+    with open(filepath) as stats:
+        print(f"Opening stats file at path {filepath}")
+        for line in stats:
+            # print(line)
+            tmp = line.split()
+            if len(tmp) > 1:
+                stats_dict[tmp[0]] = tmp[1]
+    stats_dict.pop("----------", None)
+
+
+cache_hierarchy = PrivateL1PrivateL2CacheHierarchy(
+    l1d_size="16KiB",
+    l1i_size="16KiB",
+    l2_size="256KiB",
+)
+memory = SingleChannelDDR3_1600(size="3GiB")
+# processor = SimpleSwitchableProcessor(
+#     starting_core_type=CPUTypes.KVM, #ATOMIC
+#     switch_core_type=CPUTypes.TIMING,
+#     isa=ISA.X86,
+#     num_cores=1,
+# )
+processor = SimpleProcessor(
+    cpu_type=CPUTypes.KVM,  # switch to ATOMIC for final
+    isa=ISA.X86,
+    num_cores=1,
+)
+
+board = X86Board(
+    clk_freq="3GHz",
+    processor=processor,
+    memory=memory,
+    cache_hierarchy=cache_hierarchy,
+)
+
+board.set_workload(
+    obtain_resource(
+        "x86-ubuntu-24.04-boot-with-systemd", resource_version="5.0.0"
+    )
+)
+
+simulator = Simulator(board=board)
+
+simulator.run()
+
+
+print("starting data analysis: IPC comparison")
+
+cached_stats = {}
+curr_stats = {}
+
+read_stats_files("./gem5/regression_tests/cached_stats.txt", cached_stats)
+read_stats_files(f"{m5.options.outdir}/stats.txt", curr_stats)
+
+print(f"{m5.options.outdir}/stats.txt")
+
+print(curr_stats)
+try:
+    old_ipc = float(cached_stats["board.processor.cores.core.ipc"])
+    new_ipc = float(curr_stats["board.processor.cores.core.ipc"])
+
+    print(f"old IPC: {old_ipc}")
+    print(f"new IPC: {new_ipc}")
+
+    if (new_ipc / old_ipc) < 0.8:
+        print(f"New IPC is less than 80% of the old IPC!")
+        exit(1)
+
+finally:
+    shutil.move(
+        f"{m5.options.outdir}/stats.txt",
+        "./gem5/regression_tests/cached_stats.txt",
+    )

--- a/tests/gem5/regression_tests/configs/kernel-boot.py
+++ b/tests/gem5/regression_tests/configs/kernel-boot.py
@@ -113,13 +113,12 @@ print("starting data analysis: IPC comparison")
 cached_stats = {}
 curr_stats = {}
 
-read_stats_files("./gem5/regression_tests/cached_stats.txt", cached_stats)
-read_stats_files(f"{m5.options.outdir}/stats.txt", curr_stats)
-
-print(f"{m5.options.outdir}/stats.txt")
-
-print(curr_stats)
+# print(f"{m5.options.outdir}/stats.txt")
+# print(curr_stats)
 try:
+    read_stats_files("./gem5/regression_tests/cached_stats.txt", cached_stats)
+    read_stats_files(f"{m5.options.outdir}/stats.txt", curr_stats)
+
     old_ipc = float(cached_stats["board.processor.cores.core.ipc"])
     new_ipc = float(curr_stats["board.processor.cores.core.ipc"])
 

--- a/tests/gem5/regression_tests/configs/kernel-boot.py
+++ b/tests/gem5/regression_tests/configs/kernel-boot.py
@@ -81,7 +81,8 @@ memory = SingleChannelDDR3_1600(size="3GiB")
 #     num_cores=1,
 # )
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.KVM,  # switch to ATOMIC for final
+    # cpu_type=CPUTypes.KVM,  # switch to ATOMIC for final
+    cpu_type=CPUTypes.ATOMIC,
     isa=ISA.X86,
     num_cores=1,
 )
@@ -95,7 +96,7 @@ board = X86Board(
 
 board.set_workload(
     obtain_resource(
-        "x86-ubuntu-24.04-boot-with-systemd", resource_version="5.0.0"
+        "x86-ubuntu-24.04-boot-no-systemd", resource_version="4.0.0"
     )
 )
 

--- a/tests/gem5/regression_tests/configs/kernel-boot.py
+++ b/tests/gem5/regression_tests/configs/kernel-boot.py
@@ -84,8 +84,8 @@ memory = SingleChannelDDR3_1600(size="3GiB")
 #     num_cores=1,
 # )
 processor = SimpleProcessor(
-    cpu_type=CPUTypes.KVM,  # switch to ATOMIC for final
-    # cpu_type=CPUTypes.ATOMIC,
+    # cpu_type=CPUTypes.KVM,  # switch to ATOMIC for final
+    cpu_type=CPUTypes.ATOMIC,
     isa=ISA.X86,
     num_cores=1,
 )

--- a/tests/gem5/regression_tests/configs/kernel-boot.py
+++ b/tests/gem5/regression_tests/configs/kernel-boot.py
@@ -24,6 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import shutil
 
 import m5
@@ -43,6 +44,8 @@ from gem5.resources.resource import obtain_resource
 from gem5.simulate.exit_handler import KernelBootedExitHandler
 from gem5.simulate.simulator import Simulator
 from gem5.utils.override import overrides
+
+print(f"Current working directory is: {os.getcwd()}")
 
 
 class KernelBootProcessorSwitch(KernelBootedExitHandler):

--- a/tests/gem5/regression_tests/test_regression_tests.py
+++ b/tests/gem5/regression_tests/test_regression_tests.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025 The Regents of the University of California
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met: redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer;
+# redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution;
+# neither the name of the copyright holders nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from testlib import *
+from testlib.log import *
+
+gem5_verify_config(
+    name="test-regression-tests-kernel-boot",
+    fixtures=(),
+    verifiers=(),
+    gem5_args=[],
+    config=joinpath(
+        config.base_dir,
+        "tests",
+        "gem5",
+        "regression_tests",
+        "configs",
+        "kernel-boot.py",
+    ),
+    config_args=[],
+    valid_isas=(constants.all_compiled_tag,),
+    valid_hosts=constants.supported_hosts,
+    length=constants.long_tag,
+    # uses_kvm=False,
+)


### PR DESCRIPTION
Code for tests that use the GitHub Actions cache to compare the current run's stats with the previous day's stats. Putting this somewhere safe so it doesn't get lost.